### PR TITLE
FEATURE : Add nodemon to start:dev for hot-reloading(auto reload)

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
     "build:dev": "webpack --config build/webpack.config.js",
     "watch": "webpack --config build/webpack.config.js --watch",
     "start": "node ./dist/main.min.js",
-    "start:dev": "node ./dist/main.js"
+    "start:dev": "nodemon ./dist/main.js"
   },
   "author": "{{ author }}",
   "license": "{{ license }}",
@@ -24,6 +24,7 @@
     "vue-template-compiler": "^2.5.17",
     "vuido-template-compiler": "^0.2.0",
     "webpack": "^4.16.5",
-    "webpack-cli": "^3.1.0"
+    "webpack-cli": "^3.1.0",
+    "nodemon": "^1.18.11"
   }
 }


### PR DESCRIPTION
Hi,

I notied that there is an npm watch script that handles auto building, however there is no script that restarts node when the dist folder changes. The changes are pretty small so no explanation needed really. 